### PR TITLE
Change CondaRecognizer to change CMAKE_INSTALL_PREFIX only if it was not overriden by the user

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,8 +93,8 @@ endif()
 set(REAKTORO_THIRDPARTY_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/thirdparty/install)
 
 # Set path variables for the include and lib directories of the installed dependencies
-set(REAKTORO_THIRDPARTY_INCLUDE_PATH ${REAKTORO_THIRDPARTY_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR})
-set(REAKTORO_THIRDPARTY_LIBRARY_PATH ${REAKTORO_THIRDPARTY_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
+set(REAKTORO_THIRDPARTY_INCLUDE_PATH ${REAKTORO_THIRDPARTY_INSTALL_PREFIX}/include)
+set(REAKTORO_THIRDPARTY_LIBRARY_PATH ${REAKTORO_THIRDPARTY_INSTALL_PREFIX}/lib)
 
 # Add the root path of this project to the cmake include directories
 include_directories(${PROJECT_SOURCE_DIR})
@@ -105,7 +105,7 @@ include_directories(${REAKTORO_THIRDPARTY_INCLUDE_PATH})
 # Add the library path of the installed external dependencies to the cmake link directories
 link_directories(${REAKTORO_THIRDPARTY_LIBRARY_PATH})
 
-# Find the Boost library 
+# Find the Boost library
 find_package(Boost REQUIRED)
 
 # Add the boost include path to the cmake include directories
@@ -157,7 +157,7 @@ add_subdirectory(utilities EXCLUDE_FROM_ALL)
 add_custom_target(python
     COMMAND ${CMAKE_MAKE_PROGRAM}
     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/python")
-    
+
 # Add target "interpreter" for manual building of interpreter, as `make interpreter`, if REAKTORO_BUILD_INTERPRETER is OFF
 add_custom_target(interpreter
     COMMAND ${CMAKE_MAKE_PROGRAM}

--- a/cmake/CondaRecognizer.cmake
+++ b/cmake/CondaRecognizer.cmake
@@ -1,18 +1,9 @@
 # This cmake module determines if a conda environment is active.
 # If so, CMAKE_INSTALL_PREFIX is set to the environmental variable CONDA_PREFIX.
-# This automatic behavior can prevented by passing the option -DCMAKE_CONDA_IGNORE=TRUE
+# This automatic behavior can be overriden by manually specifying a different CMAKE_INSTALL_PREFIX.
 
-
-# Keep the previous value of CMAKE_INSTALL_PREFIX before a possible change to CONDA_PREFIX
-set(CMAKE_INSTALL_PREFIX_BEFORE_CONDA_PREFIX ${CMAKE_INSTALL_PREFIX})
-
-# Check if a conda environment is active
-if(DEFINED ENV{CONDA_PREFIX} AND NOT CMAKE_CONDA_IGNORE)
+# Check if user didn't override CMAKE_INSTALL_PREFIX and a conda environment is active
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT and DEFINED ENV{CONDA_PREFIX})
     message(STATUS "Conda environment recognized in $ENV{CONDA_PREFIX}")
     set(CMAKE_INSTALL_PREFIX $ENV{CONDA_PREFIX})
-endif()
-
-# If conda environment should be ignored, then set CMAKE_INSTALL_PREFIX to its previous value
-if(CMAKE_CONDA_IGNORE)
-    set(CMAKE_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX_BEFORE_CONDA_PREFIX})
 endif()


### PR DESCRIPTION
Hi @allanleal, this is a small suggestion to your PR to change the behavior of CondaRecognizer. I think this way, if the user passes `-DCMAKE_INSTALL_PREFIX=something`, we'll honor the user choice (it should use the conda env if the user passes nothing). It also contains a small fix for the thirdparty projects in platforms where there is a `lib64`.
