### PR TITLE
Print warning message when a equilibrium/kinetics calculation fails

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ include(CCache)
 include(CMakeRC)
 
 # Set the name of the project, its version and other information
-project(Reaktoro VERSION 2.9.0 LANGUAGES CXX)
+project(Reaktoro VERSION 2.9.1 LANGUAGES CXX)
 
 # Generate compile_commands.json file in the binary directory
 if(NOT MSVC)


### PR DESCRIPTION
This pull request implements a warning message when  a equilibrium/kinetics calculation fails. The current message is:


~~~text
***WARNING***
The chemical equilibrium/kinetics calculation did not converge.
This can occur due to various factors, such as:
  1. Infeasible Problem Formulation: The problem you have defined lacks a feasible solution within the given constraints and assumptions.
  2. Out-of-Range Thermodynamic Conditions: The conditions you have specified for the system may fall outside the valid range supported by the thermodynamic models used.
  3. Numerical Instabilities: Convergence issues may arise from numerical problems during the execution of the chemical/kinetic equilibrium algorithm. Consider reporting the issue with a minimal reproducible example if you believe the algorithm is responsible for this issue.
Disable this warning message with Warnings.disable(906) in Python and Warnings::disable(906) in C++.
~~~

Fixes #314